### PR TITLE
fix: Incorrect Navigation Rail Item colors with the 2025 color spec

### DIFF
--- a/app/src/main/java/org/nsh07/wikireader/ui/AppNavigationDrawer.kt
+++ b/app/src/main/java/org/nsh07/wikireader/ui/AppNavigationDrawer.kt
@@ -239,15 +239,11 @@ private fun AppNavigationRailContent(
         selectedIndicatorColor = colorScheme.secondaryContainer,
     )
 
-    val sectionItemSelectedTextColor by animateColorAsState(
-        if (!expanded) colorScheme.onSurface else colorScheme.onSurface,
-        animationSpec = motionScheme.defaultSpatialSpec(),
-    )
     val sectionColors = WideNavigationRailItemDefaults.colors(
         unselectedIconColor = colorScheme.onSurfaceVariant,
         unselectedTextColor = colorScheme.onSurfaceVariant,
         selectedIconColor = colorScheme.onSurface,
-        selectedTextColor = sectionItemSelectedTextColor,
+        selectedTextColor = colorScheme.onSurface,
         selectedIndicatorColor = colorScheme.surfaceContainerHighest,
     )
 


### PR DESCRIPTION
This PR contains 2 important changes:
1. It fixes contrast issues in Navigation Rail Items, caused by a bug in the Material 3 Expressive Design Spec.
2. Changes Navigation Rail Section Item (custom component, based on Navigation Rail Item) active indicator color to `md.sys.color.surface-container-highest`, selected label text color to `md.sys.color.on-surface` (see discussion in #253)

Closes #253.