### PR TITLE
fix: table ordering by correcting rowspan logic

### DIFF
--- a/app/src/main/java/org/nsh07/wikireader/parser/tableAndInfoboxUtil.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/tableAndInfoboxUtil.kt
@@ -46,14 +46,16 @@ suspend fun parseWikitable(
     var insideTable = false
 
     for (line in lines) {
-        val currSize = currentRow.size
-        if (rowSpan[currSize] != null) {
-            if (rowSpan[currSize]!! - 1 > 0) {
-                currentRow.add(AnnotatedString(""))
-                rowSpan[currSize] = rowSpan[currSize]!! - 1
-            } else
-                rowSpan.remove(currSize)
+        var currColumnIndex = currentRow.size
+
+        while(rowSpan[currColumnIndex] != null && rowSpan[currColumnIndex]!! - 1 > 0) {
+            currentRow.add(AnnotatedString(""))
+            rowSpan[currColumnIndex] = rowSpan[currColumnIndex]!! - 1
+            if (rowSpan[currColumnIndex]!! <= 1)
+                rowSpan.remove(currColumnIndex)
+            currColumnIndex++
         }
+
         when {
             line.startsWith("{|") -> {
                 // Table begin

--- a/app/src/test/java/org/nsh07/wikireader/parser/ParseWikitableTest.kt
+++ b/app/src/test/java/org/nsh07/wikireader/parser/ParseWikitableTest.kt
@@ -1,0 +1,102 @@
+package org.nsh07.wikireader.parser
+
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class ParseWikitableTest {
+
+    @Test
+    fun parseWikitable_withSingleRowspan_buildsCorrectGrid() =
+        runBlocking {
+            val table = """
+                {| class="wikitable sortable plainrowheader"
+                !scope="col" rowspan="2" | Header A
+                | Cell A
+                |-
+                | Cell B
+                |-
+                |}
+            """.trimIndent()
+
+            val expectedTable = listOf(
+                listOf("Header A", "Cell A"),
+                listOf("", "Cell B")
+            )
+
+            val result = parseWikitable(
+                table = table,
+                colorScheme = darkColorScheme(),
+                typography = Typography(),
+                loadPage = { },
+                showRef = { },
+                fontSize = 18,
+            )
+            val resultTableText = result.second.map { row -> row.map { cell -> cell.text } }
+            assertEquals(expectedTable, resultTableText)
+        }
+
+    @Test
+    fun parseWikitable_withMultipleRowspans_buildsCorrectGrid() =
+        runBlocking {
+            val table =
+                """
+                {| class="wikitable sortable plainrowheaders"
+                |+Video games
+                !scope="col" rowspan="2" | Year
+                !scope="col" rowspan="2" | Title
+                !scope="col" colspan="4" | Platform(s)
+                !scope="col" rowspan="2" | Ref(s)
+                |-
+                !scope="col"| PC
+                !scope="col"| Console
+                !scope="col"| Handheld
+                !scope="col"| Mobile
+                |-
+                | 2020
+                !scope="row"| ''Game 1''
+                | -
+                | Xbox
+                | -
+                | -
+                | -
+                |-
+                | 2025
+                !scope="row"| ''Game 2''
+                | Windows
+                | -
+                | -
+                | -
+                | -
+                |-
+                |}
+                """.trimIndent()
+            val expectedCaption = "Video games"
+            val expectedTable =
+                listOf(
+                    listOf("Year", "Title", "Platform(s)", "", "", "", "Ref(s)"),
+                    listOf("", "", "PC", "Console", "Handheld", "Mobile", ""),
+                    listOf("2020", "Game 1", "-", "Xbox", "-", "-", "-"),
+                    listOf("2025", "Game 2", "Windows", "-", "-", "-", "-"),
+                )
+
+            val result =
+                parseWikitable(
+                    table = table,
+                    colorScheme = darkColorScheme(),
+                    typography = Typography(),
+                    loadPage = { },
+                    showRef = { },
+                    fontSize = 18,
+                )
+            assertNotNull(result)
+
+            val resultCaptionText = result.first.text
+            val resultTableText = result.second.map { row -> row.map { cell -> cell.text } }
+            assertEquals(expectedCaption, resultCaptionText)
+            assertEquals(expectedTable, resultTableText)
+        }
+}


### PR DESCRIPTION
The `parseWikitable` function was skipping checks for adjacent cells when applying rowspans causing the columns to be shifted.

Changes:
- Fixed row spanning logic in `parseWikitable` function.
- Added `ParseWikitableTest` file to verify this fix.

Before:
<img width="463" height="865" alt="image" src="https://github.com/user-attachments/assets/95a07cfa-667f-4b82-8d75-ed9fa17a447e" />
After:
<img width="468" height="876" alt="image" src="https://github.com/user-attachments/assets/dbd9996e-6bd0-40b3-aa35-c762fa3d8925" />

Fixes #321 