### PR TITLE
Fix rendering of directly included and transcluded tables {AI used GPT 5.6 Sol}

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Supports light mode, dark mode, Material You dynamic colors and 300+ Wikipedia l
 - **Data saver:** Save your limited data plan by loading text only
 - **Math expressions:** View properly rendered mathematical expressions for easily reading
   mathematical articles
+- **Tables:** Read Wikipedia tables in a mobile-friendly layout
 
 ## Translation
 

--- a/app/src/main/java/org/nsh07/wikireader/data/WikipediaRepository.kt
+++ b/app/src/main/java/org/nsh07/wikireader/data/WikipediaRepository.kt
@@ -6,6 +6,9 @@ import org.nsh07.wikireader.network.WikipediaApiService
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+internal val sectionTransclusion =
+    "\\{\\{#section:\\s*([^|}]+)\\|\\s*([^}]+)\\}\\}".toRegex(RegexOption.IGNORE_CASE)
+
 interface WikipediaRepository {
     suspend fun getPrefixSearchResults(query: String): WikiApiPrefixSearchResults
     suspend fun getSearchResults(query: String): WikiApiSearchResults
@@ -39,7 +42,9 @@ class NetworkWikipediaRepository(
 
     override suspend fun getPageContent(title: String): String =
         withContext(ioDispatcher) {
-            wikipediaPageApiService.getPageContent(title)
+            expandSectionTransclusions(wikipediaPageApiService.getPageContent(title)) {
+                wikipediaPageApiService.getPageContent(it)
+            }
         }
 
     override suspend fun getRandomResult(): WikiApiPageData =
@@ -53,4 +58,35 @@ class NetworkWikipediaRepository(
         withContext(ioDispatcher) {
             wikipediaApiService.getFeed(date)
         }
+}
+
+internal suspend fun expandSectionTransclusions(
+    wikitext: String,
+    getPageContent: suspend (String) -> String
+): String {
+    val pages = mutableMapOf<String, String>()
+
+    return buildString {
+        var lastIndex = 0
+        sectionTransclusion.findAll(wikitext).forEach { match ->
+            append(wikitext, lastIndex, match.range.first)
+            val page = match.groupValues[1].trim().replace(' ', '_')
+            val section = match.groupValues[2].trim()
+            val pageContent = pages[page] ?: runCatching {
+                getPageContent(page)
+            }.getOrNull()?.also { pages[page] = it }
+            append(pageContent?.extractSection(section) ?: match.value)
+            lastIndex = match.range.last + 1
+        }
+        append(wikitext, lastIndex, wikitext.length)
+    }
+}
+
+internal fun String.extractSection(name: String): String? {
+    val escapedName = Regex.escape(name)
+    val begin = "<section\\s+begin\\s*=\\s*[\"']?$escapedName[\"']?\\s*/>"
+        .toRegex(RegexOption.IGNORE_CASE).find(this) ?: return null
+    val end = "<section\\s+end\\s*=\\s*[\"']?$escapedName[\"']?\\s*/>"
+        .toRegex(RegexOption.IGNORE_CASE).find(this, begin.range.last + 1) ?: return null
+    return substring(begin.range.last + 1, end.range.first)
 }

--- a/app/src/main/java/org/nsh07/wikireader/data/WikipediaRepository.kt
+++ b/app/src/main/java/org/nsh07/wikireader/data/WikipediaRepository.kt
@@ -9,6 +9,8 @@ import java.time.format.DateTimeFormatter
 internal val sectionTransclusion =
     "\\{\\{#section:\\s*([^|}]+)\\|\\s*([^}]+)\\}\\}".toRegex(RegexOption.IGNORE_CASE)
 
+internal val pageTransclusion = "\\{\\{:\\s*([^{}|#]+?)\\s*\\}\\}".toRegex()
+
 interface WikipediaRepository {
     suspend fun getPrefixSearchResults(query: String): WikiApiPrefixSearchResults
     suspend fun getSearchResults(query: String): WikiApiSearchResults
@@ -42,9 +44,11 @@ class NetworkWikipediaRepository(
 
     override suspend fun getPageContent(title: String): String =
         withContext(ioDispatcher) {
-            expandSectionTransclusions(wikipediaPageApiService.getPageContent(title)) {
-                wikipediaPageApiService.getPageContent(it)
-            }
+            val fetch: suspend (String) -> String = { wikipediaPageApiService.getPageContent(it) }
+            expandPageTransclusions(
+                expandSectionTransclusions(wikipediaPageApiService.getPageContent(title), fetch),
+                fetch
+            )
         }
 
     override suspend fun getRandomResult(): WikiApiPageData =
@@ -80,6 +84,40 @@ internal suspend fun expandSectionTransclusions(
         }
         append(wikitext, lastIndex, wikitext.length)
     }
+}
+
+/**
+ * Replaces whole-page transclusions (`{{:Page name}}`) with the target page's `<onlyinclude>`
+ * content, mirroring MediaWiki's transclusion behaviour for pages such as TV season articles.
+ */
+internal suspend fun expandPageTransclusions(
+    wikitext: String,
+    getPageContent: suspend (String) -> String
+): String {
+    val pages = mutableMapOf<String, String>()
+
+    return buildString {
+        var lastIndex = 0
+        pageTransclusion.findAll(wikitext).forEach { match ->
+            append(wikitext, lastIndex, match.range.first)
+            val page = match.groupValues[1].trim().replace(' ', '_')
+            val pageContent = pages[page] ?: runCatching {
+                getPageContent(page)
+            }.getOrNull()?.also { pages[page] = it }
+            append(pageContent?.extractOnlyInclude() ?: "")
+            lastIndex = match.range.last + 1
+        }
+        append(wikitext, lastIndex, wikitext.length)
+    }
+}
+
+internal fun String.extractOnlyInclude(): String? {
+    val blocks = "<onlyinclude>(.*?)</onlyinclude>"
+        .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+        .findAll(this)
+        .map { it.groupValues[1] }
+        .toList()
+    return if (blocks.isEmpty()) null else blocks.joinToString("\n")
 }
 
 internal fun String.extractSection(name: String): String? {

--- a/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
@@ -6,9 +6,13 @@ package org.nsh07.wikireader.parser
  * @param wikitext Source Wikitext to clean up
  */
 fun cleanUpWikitext(wikitext: String): String {
-    return expandMedalsTables(wikitext)
+    return wikitext
         .replace("<!--.+?-->".toRegex(), "")
         .replace("</?onlyinclude>".toRegex(RegexOption.IGNORE_CASE), "")
+        .replace(
+            "<section\\s+(?:begin|end)\\s*=.*?/>".toRegex(RegexOption.IGNORE_CASE),
+            ""
+        )
         .replace("== \n", "==\n")
         // Convert colon-indented math to display math for proper block rendering
         // This ensures math like ": <math>formula</math>" is extracted as a block element
@@ -21,44 +25,4 @@ fun cleanUpWikitext(wikitext: String): String {
                 .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)),
             "{| class=\"wikitable\"\n"
         )
-}
-
-private fun expandMedalsTables(wikitext: String): String {
-    var result = wikitext
-    var start = result.indexOf("{{Medals table", ignoreCase = true)
-
-    while (start >= 0) {
-        val template = result.substringMatchingParen('{', '}', start)
-        if (!template.endsWith("}}")) break
-
-        val parameters = template.removePrefix("{{").removeSuffix("}}")
-            .splitNotInBraces('|', '{', '}')
-            .drop(1)
-            .mapNotNull {
-                val parts = it.split('=', limit = 2)
-                if (parts.size == 2) parts[0].trim() to parts[1].trim() else null
-            }
-            .toMap()
-        val teams = parameters.keys.mapNotNull {
-            it.takeIf { key -> key.startsWith("gold_", ignoreCase = true) }
-                ?.substringAfter('_')
-        }
-        val table = buildString {
-            append("{| class=\"wikitable\"\n")
-            parameters["caption"]?.let { append("|+ $it\n") }
-            append("! Rank !! NOC !! Gold !! Silver !! Bronze !! Total\n")
-            teams.forEachIndexed { index, team ->
-                val gold = parameters.entries.firstOrNull { it.key.equals("gold_$team", true) }?.value ?: "0"
-                val silver = parameters.entries.firstOrNull { it.key.equals("silver_$team", true) }?.value ?: "0"
-                val bronze = parameters.entries.firstOrNull { it.key.equals("bronze_$team", true) }?.value ?: "0"
-                val total = listOf(gold, silver, bronze).sumOf { it.toIntOrNull() ?: 0 }
-                append("|-\n| ${index + 1} || $team || $gold || $silver || $bronze || $total\n")
-            }
-            append("|}")
-        }
-        result = result.replaceRange(start, start + template.length, table)
-        start = result.indexOf("{{Medals table", start + table.length, ignoreCase = true)
-    }
-
-    return result
 }

--- a/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
@@ -8,6 +8,7 @@ package org.nsh07.wikireader.parser
 fun cleanUpWikitext(wikitext: String): String {
     return wikitext
         .replace("<!--.+?-->".toRegex(), "")
+        .replace("</?onlyinclude>".toRegex(RegexOption.IGNORE_CASE), "")
         .replace("== \n", "==\n")
         // Convert colon-indented math to display math for proper block rendering
         // This ensures math like ": <math>formula</math>" is extracted as a block element

--- a/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
@@ -9,6 +9,7 @@ fun cleanUpWikitext(wikitext: String): String {
     return wikitext
         .replace("<!--.+?-->".toRegex(), "")
         .replace("</?onlyinclude>".toRegex(RegexOption.IGNORE_CASE), "")
+        .replace("</?noinclude>".toRegex(RegexOption.IGNORE_CASE), "")
         .replace(
             "<section\\s+(?:begin|end)\\s*=.*?/>".toRegex(RegexOption.IGNORE_CASE),
             ""

--- a/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
@@ -6,7 +6,7 @@ package org.nsh07.wikireader.parser
  * @param wikitext Source Wikitext to clean up
  */
 fun cleanUpWikitext(wikitext: String): String {
-    return wikitext
+    return expandMedalsTables(wikitext)
         .replace("<!--.+?-->".toRegex(), "")
         .replace("</?onlyinclude>".toRegex(RegexOption.IGNORE_CASE), "")
         .replace("== \n", "==\n")
@@ -21,4 +21,44 @@ fun cleanUpWikitext(wikitext: String): String {
                 .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)),
             "{| class=\"wikitable\"\n"
         )
+}
+
+private fun expandMedalsTables(wikitext: String): String {
+    var result = wikitext
+    var start = result.indexOf("{{Medals table", ignoreCase = true)
+
+    while (start >= 0) {
+        val template = result.substringMatchingParen('{', '}', start)
+        if (!template.endsWith("}}")) break
+
+        val parameters = template.removePrefix("{{").removeSuffix("}}")
+            .splitNotInBraces('|', '{', '}')
+            .drop(1)
+            .mapNotNull {
+                val parts = it.split('=', limit = 2)
+                if (parts.size == 2) parts[0].trim() to parts[1].trim() else null
+            }
+            .toMap()
+        val teams = parameters.keys.mapNotNull {
+            it.takeIf { key -> key.startsWith("gold_", ignoreCase = true) }
+                ?.substringAfter('_')
+        }
+        val table = buildString {
+            append("{| class=\"wikitable\"\n")
+            parameters["caption"]?.let { append("|+ $it\n") }
+            append("! Rank !! NOC !! Gold !! Silver !! Bronze !! Total\n")
+            teams.forEachIndexed { index, team ->
+                val gold = parameters.entries.firstOrNull { it.key.equals("gold_$team", true) }?.value ?: "0"
+                val silver = parameters.entries.firstOrNull { it.key.equals("silver_$team", true) }?.value ?: "0"
+                val bronze = parameters.entries.firstOrNull { it.key.equals("bronze_$team", true) }?.value ?: "0"
+                val total = listOf(gold, silver, bronze).sumOf { it.toIntOrNull() ?: 0 }
+                append("|-\n| ${index + 1} || $team || $gold || $silver || $bronze || $total\n")
+            }
+            append("|}")
+        }
+        result = result.replaceRange(start, start + template.length, table)
+        start = result.indexOf("{{Medals table", start + table.length, ignoreCase = true)
+    }
+
+    return result
 }

--- a/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/cleanUpWikitext.kt
@@ -6,7 +6,7 @@ package org.nsh07.wikireader.parser
  * @param wikitext Source Wikitext to clean up
  */
 fun cleanUpWikitext(wikitext: String): String {
-    return wikitext
+    return expandEpisodeTables(wikitext)
         .replace("<!--.+?-->".toRegex(), "")
         .replace("</?onlyinclude>".toRegex(RegexOption.IGNORE_CASE), "")
         .replace("</?noinclude>".toRegex(RegexOption.IGNORE_CASE), "")
@@ -26,4 +26,90 @@ fun cleanUpWikitext(wikitext: String): String {
                 .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)),
             "{| class=\"wikitable\"\n"
         )
+}
+
+/**
+ * Converts [Episode table](https://en.wikipedia.org/wiki/Template:Episode_table) templates (used
+ * on television season pages) into standard wikitables that the app can render.
+ */
+private fun expandEpisodeTables(wikitext: String): String {
+    var result = wikitext
+    var start = result.indexOf("{{Episode table", ignoreCase = true)
+
+    while (start >= 0) {
+        val template = result.substringMatchingParen('{', '}', start)
+        if (!template.endsWith("}}")) break
+
+        val table = buildString {
+            append("{| class=\"wikitable\"\n")
+            append("! No. !! Title !! Directed by !! Written by !! Original air date\n")
+
+            var episodeStart = template.indexOf("{{Episode list", ignoreCase = true)
+            while (episodeStart >= 0) {
+                val episode = template.substringMatchingParen('{', '}', episodeStart)
+                if (!episode.endsWith("}}")) break
+
+                val params = episode.removePrefix("{{").removeSuffix("}}")
+                    .splitTemplateParameters()
+                    .mapNotNull {
+                        val parts = it.split('=', limit = 2)
+                        if (parts.size == 2) parts[0].trim().lowercase() to parts[1].trim()
+                        else null
+                    }
+                    .toMap()
+
+                val overall = params["episodenumber"] ?: ""
+                val inSeason = params["episodenumber2"] ?: ""
+                val number =
+                    if (inSeason.isNotEmpty() && inSeason != overall) "$overall ($inSeason)"
+                    else overall
+                val title = params["title"] ?: ""
+
+                append("|-\n")
+                append("| $number\n")
+                append("| ${if (title.isNotEmpty()) "\"$title\"" else ""}\n")
+                append("| ${params["directedby"] ?: ""}\n")
+                append("| ${params["writtenby"] ?: ""}\n")
+                append("| ${params["originalairdate"] ?: ""}\n")
+
+                episodeStart = template.indexOf(
+                    "{{Episode list",
+                    episodeStart + episode.length,
+                    ignoreCase = true
+                )
+            }
+            append("|}")
+        }
+        result = result.replaceRange(start, start + template.length, table)
+        start = result.indexOf("{{Episode table", start + table.length, ignoreCase = true)
+    }
+
+    return result
+}
+
+/**
+ * Splits template parameters on `|`, ignoring pipes nested in `{{...}}` templates and
+ * `[[...]]` links.
+ */
+private fun String.splitTemplateParameters(): List<String> {
+    val out = mutableListOf<String>()
+    var braceDepth = 0
+    var bracketDepth = 0
+    var curr = StringBuilder()
+
+    for (c in this) {
+        when (c) {
+            '{' -> braceDepth++
+            '}' -> braceDepth--
+            '[' -> bracketDepth++
+            ']' -> bracketDepth--
+        }
+        if (c == '|' && braceDepth == 0 && bracketDepth == 0) {
+            out.add(curr.toString())
+            curr = StringBuilder()
+        } else curr.append(c)
+    }
+    if (curr.isNotEmpty()) out.add(curr.toString())
+
+    return out
 }

--- a/app/src/main/java/org/nsh07/wikireader/parser/tableAndInfoboxUtil.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/tableAndInfoboxUtil.kt
@@ -318,10 +318,11 @@ suspend fun parseInfobox(
     val lines = infoboxSource.lines().fastFilter { it.isNotEmpty() }.drop(1)
     var currentRowKey = ""
     var currentRowVal = ""
+    var templateDepth = 0
 
     lines.fastForEach { item ->
         val it = item.trim()
-        if (it.startsWith('|') && it.contains('=')) {
+        if (templateDepth == 0 && it.startsWith('|') && it.contains('=')) {
             if (currentRowVal.matches(".{1,6}:.+".toRegex())) { // Add image data in plaintext
                 rows.add(Pair(AnnotatedString(currentRowKey), AnnotatedString(currentRowVal)))
             } else if (currentRowVal.isNotBlank()) {
@@ -351,11 +352,14 @@ suspend fun parseInfobox(
             currentRowKey = thisRow[0]
                 .trim(' ', '|')
                 .replace('_', ' ')
+                .replace("currentowner", "current owner", ignoreCase = true)
                 .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
             currentRowVal = thisRow[1].trim()
-        } else {
+        } else if (templateDepth > 0 || it != "}}") {
             currentRowVal += '\n' + it
         }
+        templateDepth = (templateDepth + it.windowed(2).count { braces -> braces == "{{" }
+                - it.windowed(2).count { braces -> braces == "}}" }).coerceAtLeast(0)
     }
 
     if (currentRowVal.isNotBlank()) {
@@ -368,7 +372,7 @@ suspend fun parseInfobox(
                     fontSize,
                     showRef = showRef
                 ),
-                currentRowVal.trim('\n', ' ', '}').toWikitextAnnotatedString(
+                currentRowVal.trim('\n', ' ').toWikitextAnnotatedString(
                     colorScheme,
                     typography,
                     loadPage,

--- a/app/src/main/java/org/nsh07/wikireader/parser/wikitextToAnnotatedString.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/wikitextToAnnotatedString.kt
@@ -871,6 +871,26 @@ fun String.toWikitextAnnotatedString(
                                 } else append("US$")
                             }
 
+                            currSubstring.startsWith("{{USD", true) -> {
+                                val amount = currSubstring.substringAfter('|', "").substringBefore('|')
+                                append("\$$amount")
+                            }
+
+                            currSubstring.startsWith("{{Euro", true) -> {
+                                val amount = currSubstring.substringAfter('|', "").substringBefore('|')
+                                append("€$amount")
+                            }
+
+                            currSubstring.startsWith("{{JPY", true) -> {
+                                val amount = currSubstring.substringAfter('|', "").substringBefore('|')
+                                append("¥$amount")
+                            }
+
+                            currSubstring.startsWith("{{GBP", true) -> {
+                                val amount = currSubstring.substringAfter('|', "").substringBefore('|')
+                                append("£$amount")
+                            }
+
                             currSubstring.startsWith("{{hatnote", ignoreCase = true) -> {
                                 val curr = currSubstring.substringAfter('|', "").replace('\n', ' ')
                                 append("''$curr''".twas())
@@ -1117,8 +1137,8 @@ fun String.toWikitextAnnotatedString(
                             currSubstring.startsWith("{{unbulleted list", true) -> {
                                 val splitList = currSubstring
                                     .substringAfter('|', "")
-                                    .splitNotInBraces('|')
-                                    .fastFilter { !it.contains('=') }
+                                    .splitNotInBraces('|', '{', '}')
+                                    .fastFilter { !it.trim().matches("[a-zA-Z_-]+\\s*=.*".toRegex()) }
                                     .fastMap { it.trim() }
                                     .joinToString("\n")
 

--- a/app/src/main/java/org/nsh07/wikireader/parser/wikitextToAnnotatedString.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/wikitextToAnnotatedString.kt
@@ -49,6 +49,39 @@ private val NUMBERED_PARAMETER = "^\\s*\\d+\\s*=\\s*".toRegex()
 
 private fun String.linkArgument(): String = replaceFirst(NUMBERED_PARAMETER, "").trim()
 
+private val HATNOTE_LABEL =
+    "^l(\\d+)\\s*=\\s*(.*)$".toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+private val NAMED_PARAMETER =
+    "^[a-zA-Z][\\w-]*\\s*=.*$".toRegex(RegexOption.DOT_MATCHES_ALL)
+private val monthNames = listOf(
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+)
+
+/**
+ * Resolves hatnote template parameters into (target, label) links, supporting `lN=` display
+ * labels (e.g. `{{main|Reacher season 1|l1=''Reacher'' season 1}}`).
+ */
+private fun hatnoteLinks(params: List<String>): List<Pair<String, String>> {
+    val labels = mutableMapOf<Int, String>()
+    val targets = mutableListOf<String>()
+
+    params.forEach { param ->
+        val label = HATNOTE_LABEL.find(param.trim())
+        if (label != null) {
+            labels[label.groupValues[1].toInt()] = label.groupValues[2].trim()
+        } else {
+            val target = param.linkArgument()
+            if (target.isNotEmpty() && !target.matches(NAMED_PARAMETER)) targets.add(target)
+        }
+    }
+
+    return targets.mapIndexed { index, target ->
+        target.substringBefore(MAGIC_SEP) to
+                (labels[index + 1] ?: target.substringAfter(MAGIC_SEP))
+    }
+}
+
 private object WikitextParserState {
     val recursionDepth: ThreadLocal<Int> = ThreadLocal.withInitial { 0 }
 }
@@ -620,46 +653,40 @@ fun String.toWikitextAnnotatedString(
                             }
 
                             currSubstring.startsWith("{{main", ignoreCase = true) -> {
-                                val curr = currSubstring.substringAfter('|')
-                                val splitList = curr.split('|').fastMap { it.linkArgument() }
+                                val links =
+                                    hatnoteLinks(currSubstring.substringAfter('|').split('|'))
                                 withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
                                     append("Main article")
-                                    if (splitList.size > 1) append("s: ")
+                                    if (links.size > 1) append("s: ")
                                     else append(": ")
-                                    splitList.fastForEachIndexed { index, it ->
+                                    links.fastForEachIndexed { index, (target, label) ->
                                         append(
-                                            "[[${it.substringBefore(MAGIC_SEP)}|${
-                                                it.substringAfter(MAGIC_SEP).replace(
-                                                    "#",
-                                                    " § "
-                                                )
-                                            }]]".twas()
+                                            "[[$target|${label.replace("#", " § ")}]]".twas()
                                         )
-                                        if (index == splitList.size - 2 && splitList.size > 1) append(
+                                        if (index == links.size - 2 && links.size > 1) append(
                                             ", and "
                                         )
-                                        else if (index < splitList.size - 1) append(", ")
+                                        else if (index < links.size - 1) append(", ")
                                     }
                                 }
                                 append('\n')
                             }
 
                             currSubstring.startsWith("{{see also", ignoreCase = true) -> {
-                                val curr = currSubstring.substringAfter('|')
-                                val splitList = curr.split('|').filterNot { it.startsWith('#') }
-                                    .fastMap { it.linkArgument() }
+                                val links = hatnoteLinks(
+                                    currSubstring.substringAfter('|').split('|')
+                                        .filterNot { it.startsWith('#') }
+                                )
                                 withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
                                     append("See also: ")
-                                    splitList.fastForEachIndexed { index, it ->
+                                    links.fastForEachIndexed { index, (target, label) ->
                                         append(
-                                            "[[${it.substringBefore(MAGIC_SEP)}|${
-                                                it.substringAfter((MAGIC_SEP)).replace("#", " § ")
-                                            }]]".twas()
+                                            "[[$target|${label.replace("#", " § ")}]]".twas()
                                         )
-                                        if (index == splitList.size - 2 && splitList.size > 1) append(
+                                        if (index == links.size - 2 && links.size > 1) append(
                                             ", and "
                                         )
-                                        else if (index < splitList.size - 1) append(", ")
+                                        else if (index < links.size - 1) append(", ")
                                     }
                                 }
                             }
@@ -889,6 +916,27 @@ fun String.toWikitextAnnotatedString(
                             currSubstring.startsWith("{{GBP", true) -> {
                                 val amount = currSubstring.substringAfter('|', "").substringBefore('|')
                                 append("£$amount")
+                            }
+
+                            listOf("{{start date", "{{end date").fastAny {
+                                currSubstring.startsWith(it, true)
+                            } -> {
+                                val params = currSubstring.substringAfter('|', "")
+                                    .splitNotInBraces('|', '{', '}')
+                                    .fastMap { it.trim() }
+                                    .fastFilter { it.isNotEmpty() && !it.contains('=') }
+                                val year = params.getOrNull(0)
+                                val month = params.getOrNull(1)?.toIntOrNull()
+                                val day = params.getOrNull(2)?.toIntOrNull()
+                                when {
+                                    year != null && month != null && month in 1..12 && day != null ->
+                                        append("${monthNames[month - 1]} $day, $year")
+
+                                    year != null && month != null && month in 1..12 ->
+                                        append("${monthNames[month - 1]} $year")
+
+                                    year != null -> append(year)
+                                }
                             }
 
                             currSubstring.startsWith("{{hatnote", ignoreCase = true) -> {

--- a/app/src/main/java/org/nsh07/wikireader/parser/wikitextToAnnotatedString.kt
+++ b/app/src/main/java/org/nsh07/wikireader/parser/wikitextToAnnotatedString.kt
@@ -45,6 +45,9 @@ import kotlin.text.Typography.ndash
 
 private const val MAGIC_SEP = "{{!}}"
 private const val MAX_WIKITEXT_RECURSION_DEPTH = 64
+private val NUMBERED_PARAMETER = "^\\s*\\d+\\s*=\\s*".toRegex()
+
+private fun String.linkArgument(): String = replaceFirst(NUMBERED_PARAMETER, "").trim()
 
 private object WikitextParserState {
     val recursionDepth: ThreadLocal<Int> = ThreadLocal.withInitial { 0 }
@@ -618,7 +621,7 @@ fun String.toWikitextAnnotatedString(
 
                             currSubstring.startsWith("{{main", ignoreCase = true) -> {
                                 val curr = currSubstring.substringAfter('|')
-                                val splitList = curr.split('|')
+                                val splitList = curr.split('|').fastMap { it.linkArgument() }
                                 withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
                                     append("Main article")
                                     if (splitList.size > 1) append("s: ")
@@ -644,6 +647,7 @@ fun String.toWikitextAnnotatedString(
                             currSubstring.startsWith("{{see also", ignoreCase = true) -> {
                                 val curr = currSubstring.substringAfter('|')
                                 val splitList = curr.split('|').filterNot { it.startsWith('#') }
+                                    .fastMap { it.linkArgument() }
                                 withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
                                     append("See also: ")
                                     splitList.fastForEachIndexed { index, it ->
@@ -1366,6 +1370,10 @@ fun String.toWikitextAnnotatedString(
                     if (input.getOrNull(i + 1) == '[') {
                         val curr = input.substring(i + 2).substringBefore("]]")
                         if (!curr.startsWith("File:", ignoreCase = true)) {
+                            val rawTarget = curr.substringBefore('|')
+                            val target = rawTarget.linkArgument().removePrefix(":")
+                            val label = if ('|' in curr) curr.substringAfter('|').linkArgument()
+                            else rawTarget
                             withLink(
                                 LinkAnnotation.Url(
                                     "",
@@ -1373,10 +1381,10 @@ fun String.toWikitextAnnotatedString(
                                         SpanStyle(color = colorScheme.primary)
                                     )
                                 ) {
-                                    loadPage(curr.substringBefore('|').substringBefore('#'))
+                                    loadPage(target.substringBefore('#'))
                                 }
                             ) {
-                                append(curr.substringAfter('|').trim().twas())
+                                append(label.twas())
                             }
                             i += 1 + curr.length + 2
                         } else i += substringMatchingParen('[', ']', i).length - 1

--- a/app/src/main/java/org/nsh07/wikireader/ui/homeScreen/AsyncInfobox.kt
+++ b/app/src/main/java/org/nsh07/wikireader/ui/homeScreen/AsyncInfobox.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
@@ -160,6 +161,12 @@ fun AsyncInfobox(
                                     fontSize = fontSize.sp,
                                     fontWeight = FontWeight.Bold,
                                     lineHeight = (24 * (fontSize / 16.0)).toInt().sp,
+                                    autoSize = TextAutoSize.StepBased(
+                                        minFontSize = 10.sp,
+                                        maxFontSize = fontSize.sp
+                                    ),
+                                    maxLines = 1,
+                                    softWrap = false,
                                     modifier = Modifier
                                         .padding(8.dp)
                                         .widthIn(max = 256.dp)

--- a/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
+++ b/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
@@ -3,6 +3,7 @@ package org.nsh07.wikireader.data
 import androidx.compose.material3.Typography
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -69,12 +70,37 @@ class MiscKtTest {
     }
 
     @Test
-    fun cleanUpWikitext_medalsTable_convertsToWikitable() {
-        val input = "<onlyinclude>{{Medals table|caption=Medals|gold_USA=2|silver_USA=1|bronze_USA=3}}</onlyinclude>"
-        val result = cleanUpWikitext(input)
+    fun sectionTransclusion_matchesPageAndSection() {
+        val match = sectionTransclusion.find("{{#section:Marvel Cinematic Universe: Phase One|Films}}")
 
-        assertEquals(true, result.startsWith("{| class=\"wikitable\""))
-        assertEquals(true, result.contains("| 1 || USA || 2 || 1 || 3 || 6"))
+        assertEquals("Marvel Cinematic Universe: Phase One", match?.groupValues?.get(1))
+        assertEquals("Films", match?.groupValues?.get(2))
+    }
+
+    @Test
+    fun expandSectionTransclusions_insertsRequestedTable() = runBlocking {
+        val article = "==== Phase One ====\n{{#section:Marvel Cinematic Universe: Phase One|Films}}"
+        val table = "{| class=\"wikitable\"\n| Iron Man\n|}"
+        val phasePage = "Before<section begin=Films />$table<section end=Films />After"
+
+        val result = expandSectionTransclusions(article) { phasePage }
+
+        assertEquals("==== Phase One ====\n$table", result)
+    }
+
+    @Test
+    fun extractSection_returnsMarkedContent() {
+        val table = "{| class=\"wikitable\"\n| Cell\n|}"
+        val source = "Before<section begin=Films />$table<section end=Films />After"
+
+        assertEquals(table, source.extractSection("Films"))
+    }
+
+    @Test
+    fun cleanUpWikitext_sectionMarkers_removesBothMarkers() {
+        val table = "{| class=\"wikitable\"\n| Cell\n|}"
+
+        assertEquals(table, cleanUpWikitext("<section begin=Films />$table<section end=Films />"))
     }
 
     @Test

--- a/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
+++ b/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.nsh07.wikireader.parser.cleanUpWikitext
+import org.nsh07.wikireader.parser.parseInfobox
 import org.nsh07.wikireader.parser.toWikitextAnnotatedString
 import kotlin.math.pow
 
@@ -63,6 +64,11 @@ class MiscKtTest {
     }
 
     @Test
+    fun cleanUpWikitext_noIncludeTag_removesTag() {
+        assertEquals("Content", cleanUpWikitext("</noinclude>Content"))
+    }
+
+    @Test
     fun cleanUpWikitext_onlyIncludeWrappedTable_removesWrapper() {
         val table = "{| class=\"wikitable\"\n| Cell\n|}"
 
@@ -101,6 +107,35 @@ class MiscKtTest {
         val table = "{| class=\"wikitable\"\n| Cell\n|}"
 
         assertEquals(table, cleanUpWikitext("<section begin=Films />$table<section end=Films />"))
+    }
+
+    @Test
+    fun parseInfobox_nestedPriceTemplates_renderCurrencies() = runBlocking {
+        val infobox = """{{Infobox computing device
+            | currentowner = [[Microsoft]]
+            | price = {{Unbulleted list
+             | '''Base''' / '''Digital Edition''' / '''Pro'''
+             | {{USD|499|link=yes}} / {{USD|399|link=yes}} / {{USD|699|link=yes}}
+             | {{Euro|499|link=yes}} / {{Euro|399|link=yes}} / {{Euro|799|link=yes}}
+             | {{JPY|49,980|link=yes}} / {{JPY|39,980|link=yes}} / {{JPY|119,980|link=yes}}
+             }}
+            }}""".trimIndent()
+
+        val rows = parseInfobox(
+            infobox,
+            lightColorScheme(),
+            Typography(),
+            {},
+            {},
+            16
+        )
+        val price = rows.first { it.first.text == "Price" }.second.text
+
+        assertEquals("Current owner", rows.first().first.text)
+        assertEquals(true, price.contains("$499 / $399 / $699"))
+        assertEquals(true, price.contains("€499 / €399 / €799"))
+        assertEquals(true, price.contains("¥49,980 / ¥39,980 / ¥119,980"))
+        assertEquals(false, price.contains("yes}}"))
     }
 
     @Test

--- a/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
+++ b/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
@@ -139,6 +139,69 @@ class MiscKtTest {
     }
 
     @Test
+    fun toWikitextAnnotatedString_mainWithLabel_rendersSingleLabelledLink() {
+        val result = "{{main|Reacher season 1|l1=''Reacher'' season 1}}".toWikitextAnnotatedString(
+            colorScheme = lightColorScheme(),
+            typography = Typography(),
+            loadPage = {},
+            fontSize = 16,
+            showRef = {}
+        )
+
+        assertEquals("Main article: Reacher season 1\n", result.text)
+    }
+
+    @Test
+    fun toWikitextAnnotatedString_startDate_rendersReadableDate() {
+        val result = "{{Start date|2022|2|4}}".toWikitextAnnotatedString(
+            colorScheme = lightColorScheme(),
+            typography = Typography(),
+            loadPage = {},
+            fontSize = 16,
+            showRef = {}
+        )
+
+        assertEquals("February 4, 2022", result.text)
+    }
+
+    @Test
+    fun cleanUpWikitext_episodeTable_convertsToWikitable() {
+        val input = """<onlyinclude>{{Episode table |background=#3B3D3E |overall=5 |episodes=
+            {{Episode list/sublist|Reacher season 1
+            | EpisodeNumber   = 1
+            | EpisodeNumber2  = 1
+            | Title           = Welcome to Margrave
+            | DirectedBy      = [[Thomas Vincent (director)|Thomas Vincent]]
+            | WrittenBy       = [[Nick Santora]]
+            | OriginalAirDate = {{Start date|2022|2|4}}
+            | ShortSummary    = At midnight, a man is shot dead.
+            | LineColor       = 3B3D3E
+            }}
+            }}</onlyinclude>""".trimIndent()
+
+        val result = cleanUpWikitext(input)
+
+        assertEquals(true, result.startsWith("{| class=\"wikitable\""))
+        assertEquals(true, result.contains("! No. !! Title !! Directed by !! Written by !! Original air date"))
+        assertEquals(true, result.contains("| \"Welcome to Margrave\""))
+        assertEquals(true, result.contains("| [[Thomas Vincent (director)|Thomas Vincent]]"))
+        assertEquals(true, result.contains("| {{Start date|2022|2|4}}"))
+        assertEquals(false, result.contains("ShortSummary"))
+        assertEquals(false, result.contains("Episode table"))
+    }
+
+    @Test
+    fun expandPageTransclusions_insertsOnlyIncludeContent() = runBlocking {
+        val article = "=== Season 1 (2022) ===\n{{:Reacher season 1}}"
+        val table = "{| class=\"wikitable\"\n| Episode\n|}"
+        val seasonPage = "==Episodes==\n<onlyinclude>$table</onlyinclude>\n==Cast=="
+
+        val result = expandPageTransclusions(article) { seasonPage }
+
+        assertEquals("=== Season 1 (2022) ===\n$table", result)
+    }
+
+    @Test
     fun toWikitextAnnotatedString_numberedMainLink_hidesParameterName() {
         val result = "{{main|1=Example}}".toWikitextAnnotatedString(
             colorScheme = lightColorScheme(),

--- a/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
+++ b/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.nsh07.wikireader.parser.cleanUpWikitext
 import kotlin.math.pow
 
 class MiscKtTest {
@@ -55,6 +56,13 @@ class MiscKtTest {
             "\nHello\n\n=== Subheading ===\n\nHello"
         )
         assertEquals(expectedSections, sections)
+    }
+
+    @Test
+    fun cleanUpWikitext_onlyIncludeWrappedTable_removesWrapper() {
+        val table = "{| class=\"wikitable\"\n| Cell\n|}"
+
+        assertEquals(table, cleanUpWikitext("<onlyInclude>$table</onlyInclude>"))
     }
 
     @Test

--- a/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
+++ b/app/src/test/java/org/nsh07/wikireader/data/MiscKtTest.kt
@@ -1,10 +1,13 @@
 package org.nsh07.wikireader.data
 
+import androidx.compose.material3.Typography
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.nsh07.wikireader.parser.cleanUpWikitext
+import org.nsh07.wikireader.parser.toWikitextAnnotatedString
 import kotlin.math.pow
 
 class MiscKtTest {
@@ -63,6 +66,28 @@ class MiscKtTest {
         val table = "{| class=\"wikitable\"\n| Cell\n|}"
 
         assertEquals(table, cleanUpWikitext("<onlyInclude>$table</onlyInclude>"))
+    }
+
+    @Test
+    fun cleanUpWikitext_medalsTable_convertsToWikitable() {
+        val input = "<onlyinclude>{{Medals table|caption=Medals|gold_USA=2|silver_USA=1|bronze_USA=3}}</onlyinclude>"
+        val result = cleanUpWikitext(input)
+
+        assertEquals(true, result.startsWith("{| class=\"wikitable\""))
+        assertEquals(true, result.contains("| 1 || USA || 2 || 1 || 3 || 6"))
+    }
+
+    @Test
+    fun toWikitextAnnotatedString_numberedMainLink_hidesParameterName() {
+        val result = "{{main|1=Example}}".toWikitextAnnotatedString(
+            colorScheme = lightColorScheme(),
+            typography = Typography(),
+            loadPage = {},
+            fontSize = 16,
+            showRef = {}
+        )
+
+        assertEquals("Main article: Example\n", result.text)
     }
 
     @Test


### PR DESCRIPTION
As title
Fix rendering of directly included and transcluded tables {AI used GPT 5.6 Sol}

The app treated these as unknown templates and discarded them